### PR TITLE
Dropped x permissions from normal user for systemctl-user command

### DIFF
--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -232,7 +232,7 @@ rm %{buildroot}/%{_docdir}/systemd/*
 mkdir -p %{buildroot}/etc/systemd/system/basic.target.wants
 
 # Add systemctl-user helper script
-install -D -m 755 %{SOURCE3} %{buildroot}/bin/systemctl-user
+install -D -m 754 %{SOURCE3} %{buildroot}/bin/systemctl-user
 
 %fdupes  %{buildroot}/%{_datadir}/man/
 


### PR DESCRIPTION
Command "systemctl-user" is intended to be used only as root. When normal user calls it, it silently fails. With this change user can see that he has no permissions to use this command.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
