### PR TITLE
[new-patch] Added systemd-208-fix-restart.patch to fix restart logic

### DIFF
--- a/rpm/systemd-208-fix-restart.patch
+++ b/rpm/systemd-208-fix-restart.patch
@@ -1,0 +1,203 @@
+This is combination of multiple git commits taken from latest systemd-212 to fix
+systemd-208 restart problem
+
+commit e10c9985bbc3cf79f12f9ec7317adfe697fa8214
+Author: Yuxuan Shui <yshuiv7@gmail.com>
+Date:   Sat Feb 15 02:38:50 2014 +0800
+
+    core: fix detection of dead processes
+
+    Commit 5ba6985b moves the UNIT_VTABLE(u)->sigchld_event before systemd
+    actually reaps the zombie. Which leads to service_load_pid_file accepting
+    zombie as a valid pid.
+
+    This fixes timeouts like:
+    [ 2746.602243] systemd[1]: chronyd.service stop-sigterm timed out. Killing.
+    [ 2836.852545] systemd[1]: chronyd.service still around after SIGKILL. Ignoring.
+    [ 2927.102187] systemd[1]: chronyd.service stop-final-sigterm timed out. Killing.
+    [ 3017.352560] systemd[1]: chronyd.service still around after final SIGKILL. Entering failed mode.
+
+commit bc6aed7b8b17901ef46c3af9513ae63372b7b413
+Author: Lennart Poettering <lennart@poettering.net>
+Date:   Wed Jan 29 20:12:18 2014 +0100
+
+    core: in containers, don't wait for cgroup empty notifications which will never come
+
+diff --git a/configure.ac b/configure.ac
+index 4f26092..64ade0d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -172,6 +172,9 @@ CC_CHECK_FLAGS_APPEND([with_ldflags], [LDFLAGS], [\
+         -Wl,-z,now])
+ AC_SUBST([OUR_LDFLAGS], "$with_ldflags $address_sanitizer_ldflags")
+ 
++AC_CHECK_SIZEOF(pid_t)
++AC_CHECK_SIZEOF(uid_t)
++
+ # ------------------------------------------------------------------------------
+ # we use python to build the man page index, and for systemd-python
+ have_python=no
+diff --git a/src/core/service.c b/src/core/service.c
+index a646b61..35053be 100644
+--- a/src/core/service.c
++++ b/src/core/service.c
+@@ -1429,6 +1429,14 @@ static int service_load_pid_file(Service *s, bool may_warn) {
+                 return -ESRCH;
+         }
+ 
++        if (get_process_state(pid) == 'Z') {
++                if (may_warn)
++                        log_info_unit(UNIT(s)->id,
++                                      "PID "PID_FMT" read from file %s is a zombie.",
++                                      pid, s->pid_file);
++                return -ESRCH;
++        }
++
+         if (s->main_pid_known) {
+                 if (pid == s->main_pid)
+                         return 0;
+diff --git a/src/core/unit.c b/src/core/unit.c
+index 4b97710..61fa0ea 100644
+--- a/src/core/unit.c
++++ b/src/core/unit.c
+@@ -48,6 +48,7 @@
+ #include "label.h"
+ #include "fileio-label.h"
+ #include "bus-errors.h"
++#include "virt.h"
+ 
+ const UnitVTable * const unit_vtable[_UNIT_TYPE_MAX] = {
+         [UNIT_SERVICE] = &service_vtable,
+@@ -2962,7 +2963,7 @@ int unit_kill_context(
+                 pid_t control_pid,
+                 bool main_pid_alien) {
+ 
+-        int sig, wait_for_exit = 0, r;
++        int sig, wait_for_exit = false, r;
+ 
+         assert(u);
+         assert(c);
+@@ -2982,7 +2983,8 @@ int unit_kill_context(
+                         log_warning_unit(u->id, "Failed to kill main process %li (%s): %s",
+                                          (long) main_pid, strna(comm), strerror(-r));
+                 } else {
+-                        wait_for_exit = !main_pid_alien;
++                        if (!main_pid_alien)
++                                wait_for_exit = true;
+ 
+                         if (c->send_sighup)
+                                 kill(main_pid, SIGHUP);
+@@ -3020,8 +3022,17 @@ int unit_kill_context(
+                         if (r != -EAGAIN && r != -ESRCH && r != -ENOENT)
+                                 log_warning_unit(u->id, "Failed to kill control group: %s", strerror(-r));
+                 } else if (r > 0) {
+-                        wait_for_exit = true;
+-                        if (c->send_sighup) {
++
++                        /* FIXME: Now, this is a terrible hack: in
++                         * containers cgroup empty notifications don't
++                         * work. Hence we'll not wait for them to run
++                         * empty for now, since there is no way to
++                         * detect when a service ends with no main PID
++                         * known... */
++
++                        /* wait_for_exit = true; */
++
++                        if (c->send_sighup && !sigkill) {
+                                 set_free(pid_set);
+ 
+                                 pid_set = unit_pid_set(main_pid, control_pid);
+diff --git a/src/shared/time-util.h b/src/shared/time-util.h
+index 7660fe1..33f2ffb 100644
+--- a/src/shared/time-util.h
++++ b/src/shared/time-util.h
+@@ -27,6 +27,9 @@
+ typedef uint64_t usec_t;
+ typedef uint64_t nsec_t;
+ 
++#define NSEC_FMT "%" PRIu64
++#define USEC_FMT "%" PRIu64
++
+ #include "macro.h"
+ 
+ typedef struct dual_timestamp {
+diff --git a/src/shared/util.c b/src/shared/util.c
+index 9be6acf..eb69e24 100644
+--- a/src/shared/util.c
++++ b/src/shared/util.c
+@@ -552,6 +552,31 @@ char *truncate_nl(char *s) {
+         return s;
+ }
+ 
++int get_process_state(pid_t pid) {
++        const char *p;
++        char state;
++        int r;
++        _cleanup_free_ char *line = NULL;
++
++        assert(pid >= 0);
++
++        p = procfs_file_alloca(pid, "stat");
++        r = read_one_line_file(p, &line);
++        if (r < 0)
++                return r;
++
++        p = strrchr(line, ')');
++        if (!p)
++                return -EIO;
++
++        p++;
++
++        if (sscanf(p, " %c", &state) != 1)
++                return -EIO;
++
++        return (unsigned char) state;
++}
++
+ int get_process_comm(pid_t pid, char **name) {
+         const char *p;
+ 
+diff --git a/src/shared/util.h b/src/shared/util.h
+index 1b845b3..3225c90 100644
+--- a/src/shared/util.h
++++ b/src/shared/util.h
+@@ -40,6 +40,22 @@
+ #include <unistd.h>
+ #include <locale.h>
+ 
++#if SIZEOF_PID_T == 4
++#  define PID_FMT "%" PRIu32
++#elif SIZEOF_PID_T == 2
++#  define PID_FMT "%" PRIu16
++#else
++#  error Unknown pid_t size
++#endif
++
++#if SIZEOF_UID_T == 4
++#  define UID_FMT "%" PRIu32
++#elif SIZEOF_UID_T == 2
++#  define UID_FMT "%" PRIu16
++#else
++#  error Unknown uid_t size
++#endif
++
+ #include "macro.h"
+ #include "time-util.h"
+ 
+@@ -215,6 +231,7 @@ char *file_in_same_dir(const char *path, const char *filename);
+ 
+ int rmdir_parents(const char *path, const char *stop);
+ 
++int get_process_state(pid_t pid);
+ int get_process_comm(pid_t pid, char **name);
+ int get_process_cmdline(pid_t pid, size_t max_length, bool comm_fallback, char **line);
+ int get_process_exe(pid_t pid, char **name);
+@@ -730,7 +747,7 @@ int unlink_noerrno(const char *path);
+                 pid_t _pid_ = (pid);                                    \
+                 char *_r_;                                              \
+                 _r_ = alloca(sizeof("/proc/") -1 + DECIMAL_STR_MAX(pid_t) + 1 + sizeof(field)); \
+-                sprintf(_r_, "/proc/%lu/" field, (unsigned long) _pid_); \
++                sprintf(_r_, "/proc/"PID_FMT"/" field, _pid_); \
+                 _r_;                                                    \
+         })
+ 

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -37,6 +37,7 @@ Patch3:         systemd-187-make-readahead-depend-on-sysinit.patch
 Patch4:         systemd-208-install-test-binaries.patch
 Patch5:         systemd-208-configure-timeout.patch
 Patch6:         systemd-208-configure-start-limit.patch
+Patch7:         systemd-208-fix-restart.patch
 Provides:       udev = %{version}
 Obsoletes:      udev < 184 
 Provides:       systemd-sysv = %{version}
@@ -158,6 +159,7 @@ glib-based applications using libudev functionality.
 %patch4 -p1
 %patch5 -p1
 %patch6 -p1
+%patch7 -p1
 
 %build
 ./autogen.sh


### PR DESCRIPTION
Problem was that when process was killed and systemd was supposed to restart it, it took very long before restart happened because systemd went to state where it waited process to exit and of course that exit never happened because process did exit already before wait started. Thus systemd had to go thru stop timeout before it started restart.
This problem was fixed in new systemd 212 and I made one patch that combines all fixes around that area.

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
