### PR TITLE
[patch] Added systemd-208-count-only-restarts.patch

### DIFF
--- a/rpm/systemd-208-count-only-restarts.patch
+++ b/rpm/systemd-208-count-only-restarts.patch
@@ -1,0 +1,62 @@
+From e24b4c602f3e70ee36bf749fd0d51b2740992e0f Mon Sep 17 00:00:00 2001
+From: Pekka Lundstrom <pekka.lundstrom@jollamobile.com>
+Date: Tue, 29 Apr 2014 09:34:07 +0300
+Subject: [PATCH] Count restarts when doing restart, not in start
+
+Signed-off-by: Pekka Lundstrom <pekka.lundstrom@jollamobile.com>
+---
+ src/core/service.c |   17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/src/core/service.c b/src/core/service.c
+index 35053be..9d5f4c6 100644
+--- a/src/core/service.c
++++ b/src/core/service.c
+@@ -2267,6 +2267,8 @@ fail:
+         service_enter_dead(s, SERVICE_FAILURE_RESOURCES, true);
+ }
+ 
++static int service_start_limit_test(Service *s);
++
+ static void service_enter_restart(Service *s) {
+         int r;
+         DBusError error;
+@@ -2286,6 +2288,13 @@ static void service_enter_restart(Service *s) {
+                 return;
+         }
+ 
++        /* Make sure we don't start services too frequently */
++        r = service_start_limit_test(s);
++        if (r < 0) {
++                service_enter_dead(s, SERVICE_FAILURE_START_LIMIT, false);
++                return;
++        }
++
+         /* Any units that are bound to this service must also be
+          * restarted. We use JOB_RESTART (instead of the more obvious
+          * JOB_START) here so that those dependency jobs will be added
+@@ -2489,7 +2498,6 @@ static int service_start_limit_test(Service *s) {
+ 
+ static int service_start(Unit *u) {
+         Service *s = SERVICE(u);
+-        int r;
+ 
+         assert(s);
+ 
+@@ -2521,13 +2529,6 @@ static int service_start(Unit *u) {
+ 
+         assert(s->state == SERVICE_DEAD || s->state == SERVICE_FAILED);
+ 
+-        /* Make sure we don't enter a busy loop of some kind. */
+-        r = service_start_limit_test(s);
+-        if (r < 0) {
+-                service_enter_dead(s, SERVICE_FAILURE_START_LIMIT, false);
+-                return r;
+-        }
+-
+         s->result = SERVICE_SUCCESS;
+         s->reload_result = SERVICE_SUCCESS;
+         s->main_pid_known = false;
+-- 
+1.7.9.5
+

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -38,6 +38,7 @@ Patch4:         systemd-208-install-test-binaries.patch
 Patch5:         systemd-208-configure-timeout.patch
 Patch6:         systemd-208-configure-start-limit.patch
 Patch7:         systemd-208-fix-restart.patch
+Patch8:         systemd-208-count-only-restarts.patch
 Provides:       udev = %{version}
 Obsoletes:      udev < 184 
 Provides:       systemd-sysv = %{version}
@@ -160,6 +161,7 @@ glib-based applications using libudev functionality.
 %patch5 -p1
 %patch6 -p1
 %patch7 -p1
+%patch8 -p1
 
 %build
 ./autogen.sh


### PR DESCRIPTION
Current systemd behavior is such that all starts for service are counted towards StartLimit. If service is manually restarted 3 times within 3 minute interval then service is put in Failed state. Even worse is if service has defined StartLimitAction=reboot then whole system is rebooted.

This Patch moves Start counting to happen only when service gets started by systemd restart logic. Now manual starts and stops for service are not counted towards failure and only real systemd restarts are counted (daemon takes exits and systemd makes restart).

Signed-off-by: Pekka Lundstrom pekka.lundstrom@jollamobile.com
