### PR TITLE
Support additional argument in reboot

### DIFF
--- a/rpm/systemd-208-support-additional-argument-in-reboot.patch
+++ b/rpm/systemd-208-support-additional-argument-in-reboot.patch
@@ -1,0 +1,193 @@
+From 353fc7a7c84108b50945a7b735368f6adc35fa6b Mon Sep 17 00:00:00 2001
+From: Matti Kosola <matti.kosola@jolla.com>
+Date: Fri, 13 Mar 2015 11:01:08 +0200
+Subject: [PATCH] Support additional argument in reboot
+
+Signed-off-by: Matti Kosola <matti.kosola@jolla.com>
+---
+ man/systemctl.xml         | 12 +++++++++++-
+ src/core/shutdown.c       | 14 +++++++++++---
+ src/shared/def.h          |  2 ++
+ src/systemctl/systemctl.c | 30 ++++++++++++++++++++++++------
+ 4 files changed, 48 insertions(+), 10 deletions(-)
+
+diff --git a/man/systemctl.xml b/man/systemctl.xml
+index e789d4b..fb246dd 100644
+--- a/man/systemctl.xml
++++ b/man/systemctl.xml
+@@ -1166,7 +1166,7 @@ kobject-uevent 1 systemd-udevd-kernel.socket systemd-udevd.service
+           </listitem>
+         </varlistentry>
+         <varlistentry>
+-          <term><command>reboot</command></term>
++          <term><command>reboot <optional><replaceable>arg</replaceable></optional></command></term>
+ 
+           <listitem>
+             <para>Shut down and reboot the system. This is mostly
+@@ -1179,6 +1179,16 @@ kobject-uevent 1 systemd-udevd-kernel.socket systemd-udevd.service
+             specified twice, the operation is immediately executed
+             without terminating any processes or unmounting any file
+             systems. This may result in data loss.</para>
++
++            <para>If the optional argument
++            <replaceable>arg</replaceable> is given, it will be passed
++            as the optional argument to the
++            <citerefentry><refentrytitle>reboot</refentrytitle><manvolnum>2</manvolnum></citerefentry>
++            system call. The value is architecture and firmware
++            specific. As an example, <literal>recovery</literal> might
++            be used to trigger system recovery, and
++            <literal>fota</literal> might be used to trigger a
++            <quote>firmware over the air</quote> update.</para>
+           </listitem>
+         </varlistentry>
+         <varlistentry>
+diff --git a/src/core/shutdown.c b/src/core/shutdown.c
+index 4709746..f4fbe50 100644
+--- a/src/core/shutdown.c
++++ b/src/core/shutdown.c
+@@ -46,6 +46,7 @@
+ #include "virt.h"
+ #include "watchdog.h"
+ #include "killall.h"
++#include "def.h"
+ 
+ #define FINALIZE_ATTEMPTS 50
+ 
+@@ -136,6 +137,7 @@ int main(int argc, char *argv[]) {
+         unsigned retries;
+         bool need_umount = true, need_swapoff = true, need_loop_detach = true, need_dm_detach = true;
+         bool in_container, use_watchdog = false;
++        _cleanup_free_ char *param = NULL;
+         char *arguments[3];
+ 
+         /* suppress shutdown status output if 'quiet' is used  */
+@@ -172,9 +174,11 @@ int main(int argc, char *argv[]) {
+ 
+         in_container = detect_container(NULL) > 0;
+ 
+-        if (streq(argv[1], "reboot"))
++        if (streq(argv[1], "reboot")) {
+                 cmd = RB_AUTOBOOT;
+-        else if (streq(argv[1], "poweroff"))
++                /* if this fails, that's OK */
++                read_one_line_file(REBOOT_PARAM_FILE, &param);
++        } else if (streq(argv[1], "poweroff"))
+                 cmd = RB_POWER_OFF;
+         else if (streq(argv[1], "halt"))
+                 cmd = RB_HALT_SYSTEM;
+@@ -327,7 +331,11 @@ int main(int argc, char *argv[]) {
+                 cmd = RB_AUTOBOOT;
+         }
+ 
+-        reboot(cmd);
++        if (param)
++                syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2,
++                        LINUX_REBOOT_CMD_RESTART2, param);
++        else
++                reboot(cmd);
+ 
+         if (errno == EPERM && in_container) {
+                 /* If we are in a container, and we lacked
+diff --git a/src/shared/def.h b/src/shared/def.h
+index e4ef735..d7e077a 100644
+--- a/src/shared/def.h
++++ b/src/shared/def.h
+@@ -41,3 +41,5 @@
+ #define LOWERCASE_LETTERS "abcdefghijklmnopqrstuvwxyz"
+ #define UPPERCASE_LETTERS "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+ #define LETTERS LOWERCASE_LETTERS UPPERCASE_LETTERS
++
++#define REBOOT_PARAM_FILE "/run/systemd/reboot-param"
+diff --git a/src/systemctl/systemctl.c b/src/systemctl/systemctl.c
+index bb7ada9..a34fddb 100644
+--- a/src/systemctl/systemctl.c
++++ b/src/systemctl/systemctl.c
+@@ -20,6 +20,8 @@
+ ***/
+ 
+ #include <sys/reboot.h>
++#include <linux/reboot.h>
++#include <sys/syscall.h>
+ #include <stdio.h>
+ #include <getopt.h>
+ #include <locale.h>
+@@ -4815,7 +4817,7 @@ static int systemctl_help(void) {
+                "  emergency                       Enter system emergency mode\n"
+                "  halt                            Shut down and halt the system\n"
+                "  poweroff                        Shut down and power-off the system\n"
+-               "  reboot                          Shut down and reboot the system\n"
++               "  reboot [ARG]                    Shut down and reboot the system\n"
+                "  kexec                           Shut down and reboot the system with kexec\n"
+                "  exit                            Request user instance exit\n"
+                "  switch-root [ROOT] [INIT]       Change to a different root file system\n"
+@@ -4829,7 +4831,7 @@ static int systemctl_help(void) {
+ 
+ static int halt_help(void) {
+ 
+-        printf("%s [OPTIONS...]\n\n"
++        printf("%s [OPTIONS...]%s\n\n"
+                "%s the system.\n\n"
+                "     --help      Show this help\n"
+                "     --halt      Halt the machine\n"
+@@ -4840,6 +4842,7 @@ static int halt_help(void) {
+                "  -d --no-wtmp   Don't write wtmp record\n"
+                "     --no-wall   Don't send wall message before halt/power-off/reboot\n",
+                program_invocation_short_name,
++               arg_action == ACTION_REBOOT   ? " [ARG]" : "",
+                arg_action == ACTION_REBOOT   ? "Reboot" :
+                arg_action == ACTION_POWEROFF ? "Power off" :
+                                                "Halt");
+@@ -5266,7 +5269,7 @@ static int halt_parse_argv(int argc, char *argv[]) {
+                 { NULL,        0,                 NULL, 0           }
+         };
+ 
+-        int c, runlevel;
++        int c, r, runlevel;
+ 
+         assert(argc >= 0);
+         assert(argv);
+@@ -5326,7 +5329,14 @@ static int halt_parse_argv(int argc, char *argv[]) {
+                 }
+         }
+ 
+-        if (optind < argc) {
++        if (arg_action == ACTION_REBOOT && argc == optind + 1) {
++                r = write_string_file(REBOOT_PARAM_FILE, argv[optind]);
++                if (r < 0) {
++                        log_error("Failed to write reboot param to "
++                                  REBOOT_PARAM_FILE": %s", strerror(-r));
++                        return r;
++                }
++        } else if (optind < argc) {
+                 log_error("Too many arguments.");
+                 return -EINVAL;
+         }
+@@ -5964,6 +5974,8 @@ done:
+ 
+ static _noreturn_ void halt_now(enum action a) {
+ 
++        _cleanup_free_ char *param = NULL;
++
+        /* Make sure C-A-D is handled by the kernel from this
+          * point on... */
+         reboot(RB_ENABLE_CAD);
+@@ -5981,8 +5993,14 @@ static _noreturn_ void halt_now(enum action a) {
+                 break;
+ 
+         case ACTION_REBOOT:
+-                log_info("Rebooting.");
+-                reboot(RB_AUTOBOOT);
++                if (read_one_line_file(REBOOT_PARAM_FILE, &param) == 0) {
++                        log_info("Rebooting with arg '%s'.", param);
++                        syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2,
++                                LINUX_REBOOT_CMD_RESTART2, param);
++                } else {
++                        log_info("Rebooting.");
++                        reboot(RB_AUTOBOOT);
++                }
+                 break;
+ 
+         default:
+-- 
+1.9.1
+

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -40,6 +40,7 @@ Patch6:         systemd-208-configure-start-limit.patch
 Patch7:         systemd-208-fix-restart.patch
 Patch8:         systemd-208-count-only-restarts.patch
 Patch9:         systemd-208-do-not-pull-4-megs-from-stack-for-journal-send-test.patch
+Patch10:        systemd-208-support-additional-argument-in-reboot.patch
 Provides:       udev = %{version}
 Obsoletes:      udev < 184 
 Provides:       systemd-sysv = %{version}
@@ -164,6 +165,7 @@ glib-based applications using libudev functionality.
 %patch7 -p1
 %patch8 -p1
 %patch9 -p1
+%patch10 -p1
 
 %build
 ./autogen.sh


### PR DESCRIPTION
Reboot syscall can be performed with an additional argument. In some systems this functionality can be useful to modify the mode of the next boot performed by the bootloader.

This patch is backported from upstream commit 37185ec80ad372907a2a9388735655a7334babb6 for Systemd 208.

https://github.com/systemd/systemd/commit/37185ec80ad372907a2a9388735655a7334babb6