### PR TITLE
[patch] Add patch from upstream: Don't wait for new data from the sensor

### DIFF
--- a/rpm/systemd-208-do-not-wait-accelerometer.patch
+++ b/rpm/systemd-208-do-not-wait-accelerometer.patch
@@ -1,0 +1,73 @@
+From a545c6e1aa31b4d7e80c9d3609d9fc4fc9921498 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Tue, 8 Jul 2014 18:29:06 +0200
+Subject: accelerometer: Don't wait for new data from the sensor
+
+Instead of waiting for new data from the sensor, which might be
+a long time coming, depending on the sensor device, ask the kernel
+for the last state for that particular input device.
+
+diff --git a/src/udev/accelerometer/accelerometer.c b/src/udev/accelerometer/accelerometer.c
+index 925d38d..32adf27 100644
+--- a/src/udev/accelerometer/accelerometer.c
++++ b/src/udev/accelerometer/accelerometer.c
+@@ -180,7 +180,7 @@ get_prev_orientation(struct udev_device *dev)
+         return string_to_orientation(value);
+ }
+ 
+-#define SET_AXIS(axis, code_) if (ev[i].code == code_) { if (got_##axis == 0) { axis = ev[i].value; got_##axis = true; } }
++#define READ_AXIS(axis, var) { memzero(&abs_info, sizeof(abs_info)); r = ioctl(fd, EVIOCGABS(axis), &abs_info); if (r < 0) return; var = abs_info.value; }
+ 
+ /* accelerometers */
+ static void test_orientation(struct udev *udev,
+@@ -189,10 +189,9 @@ static void test_orientation(struct udev *udev,
+ {
+         OrientationUp old, new;
+         _cleanup_close_ int fd = -1;
+-        struct input_event ev[64];
+-        bool got_syn = false;
+-        bool got_x = false, got_y = false, got_z = false;
++        struct input_absinfo abs_info;
+         int x = 0, y = 0, z = 0;
++        int r;
+         char text[64];
+ 
+         old = get_prev_orientation(dev);
+@@ -201,30 +200,10 @@ static void test_orientation(struct udev *udev,
+         if (fd < 0)
+                 return;
+ 
+-        while (1) {
+-                int i, r;
+-
+-                r = read(fd, ev, sizeof(struct input_event) * 64);
+-
+-                if (r < (int) sizeof(struct input_event))
+-                        return;
+-
+-                for (i = 0; i < r / (int) sizeof(struct input_event); i++) {
+-                        if (got_syn) {
+-                                if (ev[i].type == EV_ABS) {
+-                                        SET_AXIS(x, ABS_X);
+-                                        SET_AXIS(y, ABS_Y);
+-                                        SET_AXIS(z, ABS_Z);
+-                                }
+-                        }
+-                        if (ev[i].type == EV_SYN && ev[i].code == SYN_REPORT)
+-                                got_syn = true;
+-                        if (got_x && got_y && got_z)
+-                                goto read_dev;
+-                }
+-        }
++        READ_AXIS(ABS_X, x);
++        READ_AXIS(ABS_Y, y);
++        READ_AXIS(ABS_Z, z);
+ 
+-read_dev:
+         new = orientation_calc(old, x, y, z);
+         snprintf(text, sizeof(text),
+                  "ID_INPUT_ACCELEROMETER_ORIENTATION=%s", orientation_to_string(new));
+-- 
+cgit v0.10.2
+
+

--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -41,6 +41,7 @@ Patch7:         systemd-208-fix-restart.patch
 Patch8:         systemd-208-count-only-restarts.patch
 Patch9:         systemd-208-do-not-pull-4-megs-from-stack-for-journal-send-test.patch
 Patch10:        systemd-208-support-additional-argument-in-reboot.patch
+Patch11:        systemd-208-do-not-wait-accelerometer.patch
 Provides:       udev = %{version}
 Obsoletes:      udev < 184 
 Provides:       systemd-sysv = %{version}
@@ -166,6 +167,7 @@ glib-based applications using libudev functionality.
 %patch8 -p1
 %patch9 -p1
 %patch10 -p1
+%patch11 -p1
 
 %build
 ./autogen.sh


### PR DESCRIPTION
Add a new patch from upstream solving a problem with long delay while waiting for data from the accelerator device during boot process at least on iyokan, most likely some other devices have the same problem. The delay causes system boot process to wait until data is received or timeout occurs. The source of the patch is http://cgit.freedesktop.org/systemd/systemd/commit/src/udev/accelerometer/accelerometer.c?id=a545c6e1aa31b4d7e80c9d3609d9fc4fc9921498 .