### PR TITLE
[packaging] Fix wrong months in systemd.changes. Fixes JB#31047

### DIFF
--- a/rpm/systemd.changes
+++ b/rpm/systemd.changes
@@ -4,7 +4,7 @@
 * Wed Jun 26 2013 Carsten Munk <carsten.munk@jollamobile.com> - 187
 - Add traditional droid paths to firmware searches
 
-* Mon June 17 2013 Pekka Lundstrom <pekka.lundstrom@jollamobile.com> - 187
+* Mon Jun 17 2013 Pekka Lundstrom <pekka.lundstrom@jollamobile.com> - 187
 - Systemd config files separated to new package called systemd-config-mer
   Vendors can replace this package with their own configuration by 
   having a package that "Provides:   systemd-config"
@@ -12,7 +12,7 @@
 - Removed link /etc/systemd/system/multi-user.target.wants/remote-fs.target
 - Removed need for display-manager.service in graphical.target
 
-* Mon June 10 2013 Pekka Lundstrom <pekka.lundstrom@jollamobile.com> - 187
+* Mon Jun 10 2013 Pekka Lundstrom <pekka.lundstrom@jollamobile.com> - 187
 - Added helper script systemctl-user
   It can be used to run "systemctl --user" commands when logged in as root
 


### PR DESCRIPTION
[packaging] Fix wrong months in systemd.changes. Fixes JB#31047

Wrong months (June instead of Jun) cause mb2 to fail.

Signed-off-by: Igor Zhbanov igor.zhbanov@jolla.com
