### PR TITLE
[packaging] Add libtool to BuildRequires in .spec. Fixes JB#31050

### DIFF
--- a/rpm/systemd.spec
+++ b/rpm/systemd.spec
@@ -20,6 +20,7 @@ BuildRequires:  gperf
 BuildRequires:  xz-devel
 BuildRequires:  kmod-devel >= 15
 BuildRequires:  fdupes
+BuildRequires:  libtool
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 Requires:       dbus


### PR DESCRIPTION
This fixes build error.

Signed-off-by: Igor Zhbanov <igor.zhbanov@jolla.com>